### PR TITLE
Fix travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_script:
 
 script:
   - sleep 5
-  - php -l api/v1/index.php
+  - php -l api/index.php
   - php -l setup.php
   - php -l create/index.php
   - php -l client/index.php


### PR DESCRIPTION
Travis is always failing because the index.php of the API is not found.
This would fix it.